### PR TITLE
Require auto-merge and rebase for Dependabot (#49)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -65,17 +65,34 @@ jobs:
 
   auto-merge:
     needs: resolve-conflicts
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Fetch Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v1
+      - name: Mark auto-merge check for non-Dependabot PRs
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        run: |
+          echo "Skipping dependabot-auto-merge for non-Dependabot PRs."
+          exit 0  # This prevents it from failing on non-Dependabot PRs
+
+      - name: Checkout PR branch
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        uses: actions/checkout@v4
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Pull latest changes from PR branch
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git fetch origin ${{ github.event.pull_request.head.ref }}
+          git rebase origin/${{ github.event.pull_request.head.ref }} || git rebase --abort
+          git push origin HEAD --force-with-lease
 
       - name: Enable auto-merge for Dependabot PRs
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
This PR contributes to **#49** by enforcing `auto-merge` as a required check for Dependabot PRs and ensuring that they are always rebased before merging.  

### **Why This Change Is Needed**  
Previously, `gh pr merge --auto --merge "$PR_URL"` failed with:  
```
GraphQL: Base branch was modified. Review and try the merge again. (mergePullRequest)
Error: Process completed with exit code 1.
```
https://github.com/mattfsourcecode/fastify-swc-typescript-server/actions/runs/13182494086/job/36796536875

This issue occurred when the base branch was modified by `update-licenses` after Dependabot created its PR, preventing automatic merging.  

### **Key Changes:**  
- **Adds automatic rebase for Dependabot PRs** to ensure they are always up to date before merging.  
- **Makes `auto-merge` a required status check** for Dependabot PRs.  
- **Prevents `auto-merge` from affecting non-Dependabot PRs**, ensuring normal PRs are not blocked.  